### PR TITLE
+ Can to send ContentStream with Tadigrade

### DIFF
--- a/brokers/Tardigrade/brooktardigradebroker.pas
+++ b/brokers/Tardigrade/brooktardigradebroker.pas
@@ -237,7 +237,10 @@ end;
 
 procedure THTTPResponse.DoSendContent;
 begin
-  FHandle.Send(Contents.Text, ContentType, Code);
+  if Assigned(ContentStream) then
+    FHandle.SendStream(ContentStream, Code)
+  else
+    FHandle.Send(Contents.Text, ContentType, Code);
 end;
 
 procedure THTTPResponse.CollectHeaders(AHeaders: TStrings);


### PR DESCRIPTION
As I understand it, sending a stream using the `HTTPResponse.ContentStream`  property is not implemented in the Tadigrade broker: I added this functionality.

_Nuances: The stream is released in the SendStream procedure in the Tardigrade broker. Therefore, you do not need to set the FreeConentStream property to avoid collisions_